### PR TITLE
v3.5.8 - Negative scores, usage analytics update, and geography insights

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -384,6 +384,9 @@ On **Windows**, the local API server is started for local development.
 - **Dev App Service scale-up**: When `API_ENVIRONMENT` is `dev`, the dev App Service may be parked on F1 (free) by the nightly schedule. Step 0.5 wakes it up. When using `dev`, do NOT start a local API server — the mobile app connects to Azure dev via AFD.
 - **Local does NOT need scale-up**: When `API_ENVIRONMENT` is `local`, the mobile app hits `localhost:5001` (local API server), not the dev App Service.
 
+## Pull Request Conventions
+- **PR title prefix**: Always prefix the PR title with the version indicator extracted from the branch name. For example, if the branch is `users/rajsin/v3.5.8`, the PR title should start with `v3.5.8 - `.
+
 ## General Guidelines
 
 Please don't add any summary documents or markdown files unless asked.

--- a/apps/mobile/__tests__/StackRankingChart.test.tsx
+++ b/apps/mobile/__tests__/StackRankingChart.test.tsx
@@ -119,4 +119,56 @@ describe('StackRankingChart', () => {
     // All scores should be rendered
     expect(getAllByText(/\d+/).length).toBe(3);
   });
+
+  it('renders negative scores correctly', () => {
+    const data = [
+      { player: 'Alice', total: -5 },
+      { player: 'Bob', total: 10 },
+    ];
+    const { getByText } = render(<StackRankingChart data={data} />);
+    expect(getByText('-5')).toBeTruthy();
+    expect(getByText('10')).toBeTruthy();
+  });
+
+  it('gives different bar widths for negative and zero scores', () => {
+    const data = [
+      { player: 'Alice', total: -10 },
+      { player: 'Bob', total: 0 },
+      { player: 'Charlie', total: 10 },
+    ];
+    const { toJSON } = render(<StackRankingChart data={data} />);
+    const tree = JSON.stringify(toJSON());
+
+    // All three scores should be displayed
+    expect(tree).toContain('-10');
+    expect(tree).toContain('"0"'); // Exact match for 0 score text node
+    expect(tree).toContain('"10"');
+
+    // Bars should have different widths:
+    // Charlie (10): (10 - (-10)) / (10 - (-10)) * 100 = 100%
+    // Bob (0):      (0 - (-10)) / (10 - (-10)) * 100 = 50%
+    // Alice (-10):  (-10 - (-10)) / (10 - (-10)) * 100 = 0% → clamped to 15%
+    expect(tree).toContain('100%');
+    expect(tree).toContain('50%');
+    expect(tree).toContain('15%');
+  });
+
+  it('scales negative-only scores linearly', () => {
+    const data = [
+      { player: 'Alice', total: -20 },
+      { player: 'Bob', total: -10 },
+      { player: 'Charlie', total: -5 },
+    ];
+    const { toJSON } = render(<StackRankingChart data={data} />);
+    const tree = JSON.stringify(toJSON());
+
+    // min = -20, max = 1 (default), range = 21
+    // Charlie (-5): (-5 - (-20)) / 21 * 100 ≈ 71.4%
+    // Bob (-10): (-10 - (-20)) / 21 * 100 ≈ 47.6%
+    // Alice (-20): (-20 - (-20)) / 21 * 100 = 0% → clamped to 15%
+    // All scores should be rendered
+    expect(tree).toContain('-20');
+    expect(tree).toContain('-10');
+    expect(tree).toContain('-5');
+  });
 });

--- a/apps/mobile/components/scoreTracker/StackRankingChart.tsx
+++ b/apps/mobile/components/scoreTracker/StackRankingChart.tsx
@@ -24,12 +24,22 @@ export default function StackRankingChart({
     [data, sortAscending]
   );
 
-  // Calculate max value for bar scaling
+  // Calculate min/max values for bar scaling (supports negative scores)
+  const minValue = useMemo(
+    () => Math.min(...sortedData.map((d) => d.total), 0),
+    [sortedData]
+  );
+
   const maxValue = useMemo(() => {
     if (providedMaxValue !== undefined) return providedMaxValue;
     const max = Math.max(...sortedData.map((d) => d.total), 1);
     return max;
   }, [sortedData, providedMaxValue]);
+
+  const valueRange = useMemo(
+    () => maxValue - minValue,
+    [maxValue, minValue]
+  );
 
   // Generate unique initials for all players
   const initials = useMemo(
@@ -44,7 +54,7 @@ export default function StackRankingChart({
   return (
     <View style={styles.rankingContainer}>
       {sortedData.map((item, index) => {
-        const barWidth = maxValue > 0 ? (item.total / maxValue) * 100 : 0;
+        const barWidth = valueRange > 0 ? ((item.total - minValue) / valueRange) * 100 : 0;
 
         return (
           <View key={item.player} style={styles.rankingRow}>

--- a/apps/mobile/screens/ScoreInputScreen.tsx
+++ b/apps/mobile/screens/ScoreInputScreen.tsx
@@ -71,6 +71,7 @@ export default function ScoreInputScreen() {
   // State
   const [playerNames, setPlayerNames] = useState<string[]>([]);
   const [scores, setScores] = useState<Record<string, number>>({});
+  const [rawInputs, setRawInputs] = useState<Record<string, string>>({});
   const [selectedGame, setSelectedGame] = useState<GameInfo | null>(existingGame || null);
   const [showGameSearch, setShowGameSearch] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -205,14 +206,26 @@ export default function ScoreInputScreen() {
   }, [isLeaderboardMode, navigation]);
 
   const handleScoreChange = (playerName: string, value: string) => {
-    const numValue = value === '' || value === '-' ? 0 : parseInt(value, 10);
-    setScores((prev) => ({
-      ...prev,
-      [playerName]: isNaN(numValue) ? 0 : numValue,
-    }));
+    // Allow empty, minus sign, or valid integer (including negative)
+    if (value === '' || value === '-' || /^-?\d+$/.test(value)) {
+      setRawInputs((prev) => ({ ...prev, [playerName]: value }));
+      const numValue = parseInt(value, 10);
+      if (!isNaN(numValue)) {
+        setScores((prev) => ({ ...prev, [playerName]: numValue }));
+      }
+    }
+  };
+
+  const handleInputBlur = (playerName: string) => {
+    setRawInputs((prev) => {
+      const next = { ...prev };
+      delete next[playerName];
+      return next;
+    });
   };
 
   const handleIncrement = (playerName: string) => {
+    setRawInputs((prev) => { const next = { ...prev }; delete next[playerName]; return next; });
     setScores((prev) => ({
       ...prev,
       [playerName]: (prev[playerName] || 0) + 1,
@@ -220,6 +233,7 @@ export default function ScoreInputScreen() {
   };
 
   const handleDecrement = (playerName: string) => {
+    setRawInputs((prev) => { const next = { ...prev }; delete next[playerName]; return next; });
     setScores((prev) => ({
       ...prev,
       [playerName]: (prev[playerName] || 0) - 1,
@@ -392,9 +406,10 @@ export default function ScoreInputScreen() {
               </TouchableOpacity>
               <TextInput
                 style={styles.scoreInput}
-                value={String(scores[playerName] ?? 0)}
+                value={rawInputs[playerName] !== undefined ? rawInputs[playerName] : String(scores[playerName] ?? 0)}
                 onChangeText={(text) => handleScoreChange(playerName, text)}
-                keyboardType="numeric"
+                onBlur={() => handleInputBlur(playerName)}
+                keyboardType={Platform.OS === 'ios' ? 'numbers-and-punctuation' : 'numeric'}
                 selectTextOnFocus
                 testID={`score-input-${index}`}
                 {...(Platform.OS === 'web' && { 'data-testid': `score-input-${index}` })}

--- a/docs/bgg/sync/sync_status.md
+++ b/docs/bgg/sync/sync_status.md
@@ -1,6 +1,6 @@
 # BGG Game Sync Status
 
-**Total games in Cosmos DB:** 4,785  
+**Total games in Cosmos DB:** 4,829  
 **Last updated:** 2026-03-11
 
 ## Sync Batches
@@ -8,7 +8,7 @@
 | Batch | ID Range | Type | Status | Started | Position | Games Added |
 |-------|----------|------|--------|---------|----------|-------------|
 | 1 | 1 – 500 | Sequential | ✅ Complete | Pre-Feb 2026 | 500/500 | ~3,626 |
-| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~226,455 | ~1,159 |
+| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~227,422 | ~1,203 |
 | 3 | 500 – 100,000 | High-Signal | ⏳ Pending | — | — | — |
 | 4 | 100,000 – 200,000 | High-Signal | ⏳ Pending | — | — | — |
 | 5 | 300,000 – 400,000 | High-Signal | ⏳ Pending | — | — | — |

--- a/docs/bgg/sync/sync_status.md
+++ b/docs/bgg/sync/sync_status.md
@@ -1,14 +1,14 @@
 # BGG Game Sync Status
 
-**Total games in Cosmos DB:** 4,829  
-**Last updated:** 2026-03-11
+**Total games in Cosmos DB:** 5,096  
+**Last updated:** 2026-03-13
 
 ## Sync Batches
 
 | Batch | ID Range | Type | Status | Started | Position | Games Added |
 |-------|----------|------|--------|---------|----------|-------------|
 | 1 | 1 – 500 | Sequential | ✅ Complete | Pre-Feb 2026 | 500/500 | ~3,626 |
-| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~227,422 | ~1,203 |
+| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~232,187 | ~1,470 |
 | 3 | 500 – 100,000 | High-Signal | ⏳ Pending | — | — | — |
 | 4 | 100,000 – 200,000 | High-Signal | ⏳ Pending | — | — | — |
 | 5 | 300,000 – 400,000 | High-Signal | ⏳ Pending | — | — | — |

--- a/docs/bgg/sync/sync_status.md
+++ b/docs/bgg/sync/sync_status.md
@@ -1,14 +1,14 @@
 # BGG Game Sync Status
 
-**Total games in Cosmos DB:** 5,096  
-**Last updated:** 2026-03-13
+**Total games in Cosmos DB:** 5,286  
+**Last updated:** 2026-03-15
 
 ## Sync Batches
 
 | Batch | ID Range | Type | Status | Started | Position | Games Added |
 |-------|----------|------|--------|---------|----------|-------------|
 | 1 | 1 – 500 | Sequential | ✅ Complete | Pre-Feb 2026 | 500/500 | ~3,626 |
-| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~232,187 | ~1,470 |
+| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~235,296 | ~1,660 |
 | 3 | 500 – 100,000 | High-Signal | ⏳ Pending | — | — | — |
 | 4 | 100,000 – 200,000 | High-Signal | ⏳ Pending | — | — | — |
 | 5 | 300,000 – 400,000 | High-Signal | ⏳ Pending | — | — | — |

--- a/docs/bgg/sync/sync_status.md
+++ b/docs/bgg/sync/sync_status.md
@@ -1,14 +1,14 @@
 # BGG Game Sync Status
 
-**Total games in Cosmos DB:** 4,472  
-**Last updated:** 2026-03-09
+**Total games in Cosmos DB:** 4,669  
+**Last updated:** 2026-03-10
 
 ## Sync Batches
 
 | Batch | ID Range | Type | Status | Started | Position | Games Added |
 |-------|----------|------|--------|---------|----------|-------------|
 | 1 | 1 – 500 | Sequential | ✅ Complete | Pre-Feb 2026 | 500/500 | ~3,626 |
-| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~219,399 | ~846 |
+| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~223,990 | ~1,043 |
 | 3 | 500 – 100,000 | High-Signal | ⏳ Pending | — | — | — |
 | 4 | 100,000 – 200,000 | High-Signal | ⏳ Pending | — | — | — |
 | 5 | 300,000 – 400,000 | High-Signal | ⏳ Pending | — | — | — |

--- a/docs/bgg/sync/sync_status.md
+++ b/docs/bgg/sync/sync_status.md
@@ -1,14 +1,14 @@
 # BGG Game Sync Status
 
-**Total games in Cosmos DB:** 5,467  
-**Last updated:** 2026-03-18
+**Total games in Cosmos DB:** 5,607  
+**Last updated:** 2026-03-22
 
 ## Sync Batches
 
 | Batch | ID Range | Type | Status | Started | Position | Games Added |
 |-------|----------|------|--------|---------|----------|-------------|
 | 1 | 1 – 500 | Sequential | ✅ Complete | Pre-Feb 2026 | 500/500 | ~3,626 |
-| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~239,292 | ~1,841 |
+| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~243,434 | ~1,981 |
 | 3 | 500 – 100,000 | High-Signal | ⏳ Pending | — | — | — |
 | 4 | 100,000 – 200,000 | High-Signal | ⏳ Pending | — | — | — |
 | 5 | 300,000 – 400,000 | High-Signal | ⏳ Pending | — | — | — |

--- a/docs/bgg/sync/sync_status.md
+++ b/docs/bgg/sync/sync_status.md
@@ -1,14 +1,14 @@
 # BGG Game Sync Status
 
-**Total games in Cosmos DB:** 4,669  
-**Last updated:** 2026-03-10
+**Total games in Cosmos DB:** 4,785  
+**Last updated:** 2026-03-11
 
 ## Sync Batches
 
 | Batch | ID Range | Type | Status | Started | Position | Games Added |
 |-------|----------|------|--------|---------|----------|-------------|
 | 1 | 1 – 500 | Sequential | ✅ Complete | Pre-Feb 2026 | 500/500 | ~3,626 |
-| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~223,990 | ~1,043 |
+| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~226,455 | ~1,159 |
 | 3 | 500 – 100,000 | High-Signal | ⏳ Pending | — | — | — |
 | 4 | 100,000 – 200,000 | High-Signal | ⏳ Pending | — | — | — |
 | 5 | 300,000 – 400,000 | High-Signal | ⏳ Pending | — | — | — |

--- a/docs/bgg/sync/sync_status.md
+++ b/docs/bgg/sync/sync_status.md
@@ -1,14 +1,14 @@
 # BGG Game Sync Status
 
-**Total games in Cosmos DB:** 5,286  
-**Last updated:** 2026-03-15
+**Total games in Cosmos DB:** 5,377  
+**Last updated:** 2026-03-16
 
 ## Sync Batches
 
 | Batch | ID Range | Type | Status | Started | Position | Games Added |
 |-------|----------|------|--------|---------|----------|-------------|
 | 1 | 1 – 500 | Sequential | ✅ Complete | Pre-Feb 2026 | 500/500 | ~3,626 |
-| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~235,296 | ~1,660 |
+| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~237,018 | ~1,751 |
 | 3 | 500 – 100,000 | High-Signal | ⏳ Pending | — | — | — |
 | 4 | 100,000 – 200,000 | High-Signal | ⏳ Pending | — | — | — |
 | 5 | 300,000 – 400,000 | High-Signal | ⏳ Pending | — | — | — |

--- a/docs/bgg/sync/sync_status.md
+++ b/docs/bgg/sync/sync_status.md
@@ -1,14 +1,14 @@
 # BGG Game Sync Status
 
-**Total games in Cosmos DB:** 5,377  
-**Last updated:** 2026-03-16
+**Total games in Cosmos DB:** 5,467  
+**Last updated:** 2026-03-18
 
 ## Sync Batches
 
 | Batch | ID Range | Type | Status | Started | Position | Games Added |
 |-------|----------|------|--------|---------|----------|-------------|
 | 1 | 1 – 500 | Sequential | ✅ Complete | Pre-Feb 2026 | 500/500 | ~3,626 |
-| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~237,018 | ~1,751 |
+| 2 | 200,000 – 300,000 | High-Signal | 🟠 In Progress | 2026-03-01 | ~239,292 | ~1,841 |
 | 3 | 500 – 100,000 | High-Signal | ⏳ Pending | — | — | — |
 | 4 | 100,000 – 200,000 | High-Signal | ⏳ Pending | — | — | — |
 | 5 | 300,000 – 400,000 | High-Signal | ⏳ Pending | — | — | — |

--- a/docs/telemetry/usage_analytics.md
+++ b/docs/telemetry/usage_analytics.md
@@ -101,14 +101,44 @@ Feature taps from the Landing screen and corresponding screen views. Each featur
 
 ---
 
-## 4. Rating Prompt
+## 4. Geography
+
+> **Note**: Geo data is derived from IP-based geolocation by Application Insights (`ClientCountryOrRegion`, `ClientStateOrProvince`, `ClientCity` fields). Accuracy may vary for VPN or carrier NAT users. This table is **replaced** each snapshot (not appended).
+
+**Snapshot: 2026-03-20 (Mar 7 – Mar 20) — by country:**
+
+| Country | Devices | Events | % of Events |
+|---|---|---|---|
+| United States | 12 | 751 | 98% |
+| United Kingdom | 1 | 18 | 2% |
+
+**Top US states/cities:**
+
+| State | City | Devices | Events |
+|---|---|---|---|
+| Washington | Mill Creek | 3 | 282 |
+| Washington | Ocean Shores | 1 | 125 |
+| Georgia | Atlanta | 1 | 74 |
+| Ohio | Cleveland | 1 | 63 |
+| Washington | Mountlake Terrace | 1 | 58 |
+| Washington | Bellevue | 1 | 34 |
+| California | East Garrison | 1 | 33 |
+| New York | Levittown | 1 | 29 |
+| Utah | Salt Lake City | 1 | 22 |
+| Washington | Lake Forest Park | 1 | 15 |
+| California | Los Angeles | 1 | 13 |
+| California | Cupertino | 1 | 3 |
+
+---
+
+## 5. Rating Prompt
 
 | Snapshot Date | Window | Shown | Dismissed | Rated | Conversion |
 |---|---|---|---|---|---|
 | 2026-03-20 | Mar 7 – Mar 20 | 14 | 13 | 1 | 7% |
 | 2026-03-04 | Feb 19 – Mar 4 | 16 | 13 | 3 | 19% |
 
-## 5. Upgrade Prompt
+## 6. Upgrade Prompt
 
 | Snapshot Date | Window | Prompted | Accepted | Dismissed | Conversion |
 |---|---|---|---|---|---|

--- a/docs/telemetry/usage_analytics.md
+++ b/docs/telemetry/usage_analytics.md
@@ -14,6 +14,7 @@ Each row is a 14-day rolling window snapshot taken on the specified date.
 
 | Snapshot Date | Window | Devices | New Users | Sessions | Events | D1 Return Devices | D7 Return Devices |
 |---|---|---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 13 | 8 | 33 | 1,105 | 5 | 0 |
 | 2026-03-04 | Feb 19 – Mar 4 | 22 | 17 | 85 | 1,634 | 5 | 1 |
 
 **Key metrics:**
@@ -32,65 +33,71 @@ Feature taps from the Landing screen and corresponding screen views. Each featur
 
 | Snapshot Date | Window | Taps | Unique Devices | Screen Views | View Devices |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 19 | 8 | 22 | 9 |
 | 2026-03-04 | Feb 19 – Mar 4 | 73 | 17 | 82 | 17 |
 
 ### Game Setup
 
 | Snapshot Date | Window | Taps | Unique Devices | Screen Views | View Devices |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 21 | 7 | 21 | 7 |
 | 2026-03-04 | Feb 19 – Mar 4 | 51 | 15 | 52 | 15 |
 
 ### Game Search
 
 | Snapshot Date | Window | Taps | Unique Devices | Screen Views | View Devices |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 18 | 10 | 21 | 10 |
 | 2026-03-04 | Feb 19 – Mar 4 | 51 | 12 | 59 | 12 |
 
 ### Turn Selector
 
 | Snapshot Date | Window | Taps | Unique Devices | Screen Views | View Devices |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 18 | 8 | 18 | 8 |
 | 2026-03-04 | Feb 19 – Mar 4 | 40 | 11 | 40 | 11 |
 
 ### Dice Roller
 
 | Snapshot Date | Window | Taps | Unique Devices | Screen Views | View Devices |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 11 | 6 | 11 | 6 |
 | 2026-03-04 | Feb 19 – Mar 4 | 34 | 15 | 34 | 15 |
 
 ### Timer
 
 | Snapshot Date | Window | Taps | Unique Devices | Screen Views | View Devices |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 7 | 5 | 7 | 5 |
 | 2026-03-04 | Feb 19 – Mar 4 | 34 | 13 | 34 | 13 |
 
 ### Team Randomizer
 
 | Snapshot Date | Window | Taps | Unique Devices | Screen Views | View Devices |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 13 | 6 | 13 | 6 |
 | 2026-03-04 | Feb 19 – Mar 4 | 33 | 12 | 33 | 12 |
 
 ### Score Tracker
 
 | Snapshot Date | Window | Taps | Unique Devices | Screen Views | View Devices |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 36 | 10 | 100 | 10 |
 | 2026-03-04 | Feb 19 – Mar 4 | 25 | 10 | 40 | 10 |
 
 ---
 
 ## 3. Version Adoption
 
-**Current snapshot (2026-03-04):**
+> **Note**: This table is **replaced** each snapshot (not appended) since version mix changes completely across periods.
+
+**Snapshot: 2026-03-20 (Mar 7 – Mar 20):**
 
 | Version | Sessions | Devices | % of Sessions |
 |---|---|---|---|
-| 3.4.1 | 9 | 6 | 15% |
-| 3.4.0 | 5 | 4 | 8% |
-| 3.3.4 | 16 | 9 | 26% |
-| 3.3.3 | 17 | 7 | 28% |
-| 3.3.1 | 9 | 5 | 15% |
-| 3.3.0 | 1 | 1 | 2% |
-| 3.2.7 | 2 | 1 | 3% |
+| 3.5.5 | 15 | 10 | 50% |
+| 3.4.1 | 13 | 7 | 43% |
+| 3.3.4 | 2 | 1 | 7% |
 
 ---
 
@@ -98,12 +105,14 @@ Feature taps from the Landing screen and corresponding screen views. Each featur
 
 | Snapshot Date | Window | Shown | Dismissed | Rated | Conversion |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 14 | 13 | 1 | 7% |
 | 2026-03-04 | Feb 19 – Mar 4 | 16 | 13 | 3 | 19% |
 
 ## 5. Upgrade Prompt
 
 | Snapshot Date | Window | Prompted | Accepted | Dismissed | Conversion |
 |---|---|---|---|---|---|
+| 2026-03-20 | Mar 7 – Mar 20 | 0 | 0 | 0 | — |
 | 2026-03-04 | Feb 19 – Mar 4 | 5 | 2 | 4 | 40% |
 
 ---


### PR DESCRIPTION
## Changes

### Score Tracker
- Support negative scores in StackRankingChart
- Enhance ScoreInputScreen for raw input handling
- Add unit tests for negative score scenarios

### Usage Analytics
- Add Mar 7-20 snapshot to all adoption, engagement, rating, and upgrade tables
- Add new Geography section (Section 4) with country and US state/city breakdown
- Version Adoption table now replaced per snapshot (not appended), with a note

### BGG Sync Status
- Update game count and last updated date

### Copilot Instructions
- Add PR title prefix convention (version from branch name)